### PR TITLE
gtkhash: remove duplicate build-gtkhash

### DIFF
--- a/packages/app-misc/gtkhash/gtkhash-1.5.exheres-0
+++ b/packages/app-misc/gtkhash/gtkhash-1.5.exheres-0
@@ -47,7 +47,6 @@ DEPENDENCIES="
 
 MESON_SRC_CONFIGURE_PARAMS=(
     -Dappstream=false
-    -Dbuild-gtkhash=true
     -Dbuild-caja=false
     -Dbuild-nemo=false
     -Dbuild-thunar=false


### PR DESCRIPTION
Small followup to remove the duplicate build-gtkhash I introduced which is set by the gui option.